### PR TITLE
Erro ao obter o path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ exports.handler = async function (context, event, callback) {
   if (!receivedMsg) return callback("No message received", twiml);
 
   // Get response from Dialogflow
-  let diallofglowJsonFilePath = Runtime.getAssets()["/dialogflow.json"].path;
+  let diallofglowJsonFilePath = Runtime.getAssets()["dialogflow.json"].path;
   const dialogflogSessionClient = new dialogflow.SessionsClient({
     keyFilename: diallofglowJsonFilePath,
   });


### PR DESCRIPTION
Segui o vídeo e ao realizar a integração entre dialogflow x twilio estava ocorrendo erro onde não estava possível obter o path da Assets.
Após remover a barra (/), tive sucesso na integração.

* Talvez seja alguma atualização do Twilio, caso seja algo que fiz errado que acabou gerando o problema, pode desconsiderar pois para minha funcionou conforme informado.

